### PR TITLE
fixed test method AddWidgetToPlaceHolderPureMvcMode

### DIFF
--- a/Tests/Feather.Widgets.TestUI.Framework/Framework/Wrappers/Backend/Pages/PageZoneEditorWrapper.cs
+++ b/Tests/Feather.Widgets.TestUI.Framework/Framework/Wrappers/Backend/Pages/PageZoneEditorWrapper.cs
@@ -75,11 +75,11 @@ namespace Feather.Widgets.TestUI.Framework.Framework.Wrappers.Backend
         /// <param name="widgetName">The widget name.</param>
         /// <param name="placeHolder">The placeholder id.</param>
         public void AddWidgetToPlaceHolderPureMvcMode(string widgetName, string placeHolder = "Contentplaceholder1")
-        {
-            HtmlDiv radDockZone = ActiveBrowser.Find.ByExpression<HtmlDiv>("id=?" + placeHolder)
-               .AssertIsPresent<HtmlDiv>(placeHolder);
-
+        {            
             HtmlDiv widget = this.GetWidgetByName(widgetName);
+
+            HtmlDiv radDockZone = ActiveBrowser.Find.ByExpression<HtmlDiv>("placeholderid=" + placeHolder)
+               .AssertIsPresent<HtmlDiv>(placeHolder);
             BAT.Wrappers().Backend().Pages().PageZoneEditorWrapper().AddWidgetToDropZone(widget, radDockZone);
         }
 


### PR DESCRIPTION
Now the widget is get before the drop zone, since there is some delay when opening the page, and the drop zone is searched by exact placeholderid instead of div id