### PR TITLE
Fixed bug 865: Image Gallery: Back to all images doesn't return you in t...

### DIFF
--- a/Telerik.Sitefinity.Frontend.Media/Mvc/Views/ImageGallery/List.ImageGallery.cshtml
+++ b/Telerik.Sitefinity.Frontend.Media/Mvc/Views/ImageGallery/List.ImageGallery.cshtml
@@ -13,9 +13,11 @@
     {
         var item = Model.Items.ElementAt(i);
         var itemIndex = (Model.CurrentPage - 1) * ViewBag.ItemsPerPage + i + 1;
+        var detailPageUrl = ViewBag.OpenInSamePage ? HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, itemIndex) :
+            HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage);
 
 		<a
-       href="@HyperLinkHelpers.GetDetailPageUrl(item, ViewBag.DetailsPageId, ViewBag.OpenInSamePage, itemIndex)"
+       href="@detailPageUrl"
        title="@(string.IsNullOrEmpty(item.Fields.Description) ? item.Fields.Title : item.Fields.Description)">
 			<img src="@(((ThumbnailViewModel)item).ThumbnailUrl)" alt='@System.Text.RegularExpressions.Regex.Replace(item.Fields.AlternativeText, @"[^\w\d_-]", "")' />
 		</a>


### PR DESCRIPTION
...he initial page if you have a different detail view page https://github.com/Sitefinity/feather/issues/865

- [x] @PepiIvanova 
- [x] @manev 