### PR TITLE
Fix feather setup script to delete old Resource packages

### DIFF
--- a/SetupScripts/FeatherSetup.ps1
+++ b/SetupScripts/FeatherSetup.ps1
@@ -68,6 +68,11 @@ function InstallFeatherPackages($featherPackagesDirectory)
 	if(!(Test-Path -Path $resourcePackagesFolder )){
 		New-Item -ItemType directory -Path $resourcePackagesFolder
 	}
+	else {
+		Write-Output "----- Delete old Resource Packages content ------"
+		$resourcePackageSubfolders = $resourcePackagesFolder + "\*"
+		Remove-Item $resourcePackageSubfolders -recurse
+	}
 	
 	Write-Output "----- Copy packages ------"
 	Get-ChildItem Bootstrap -path $featherPackagesDirectory | Copy-Item -destination $resourcePackagesFolder -force -recurse


### PR DESCRIPTION
- [x] @sistoimenov 
- [x] @VenetaBogoeva 

Fix Feather setup script to delete old ResourcePackages content. This is causing wrong behaviour on VMs during automation tests execution.