### PR TITLE
Fixed: Not taking into account Show empty taxa if filtering by conten…

### DIFF
--- a/Telerik.Sitefinity.Frontend.Taxonomies/Mvc/Scripts/FlatTaxonomy/designerview-simple.js
+++ b/Telerik.Sitefinity.Frontend.Taxonomies/Mvc/Scripts/FlatTaxonomy/designerview-simple.js
@@ -75,6 +75,8 @@
                     }
                     else if ($scope.properties.TaxaToDisplay.PropertyValue === 'UsedByContentType') {
                         $scope.properties.SerializedSelectedTaxaIds.PropertyValue = null;
+                        // Not taking into account Show empty taxa if filtering by content type is selected
+                        $scope.properties.ShowEmptyTaxa.PropertyValue = false;
                     }
                     else if ($scope.properties.TaxaToDisplay.PropertyValue === 'Selected') {
                         $scope.properties.DynamicContentTypeName.PropertyValue =

--- a/Telerik.Sitefinity.Frontend.Taxonomies/Mvc/Scripts/HierarchicalTaxonomy/designerview-simple.js
+++ b/Telerik.Sitefinity.Frontend.Taxonomies/Mvc/Scripts/HierarchicalTaxonomy/designerview-simple.js
@@ -83,6 +83,8 @@
                     else if ($scope.properties.TaxaToDisplay.PropertyValue === 'UsedByContentType') {
                         $scope.properties.SerializedSelectedTaxaIds.PropertyValue =
                             $scope.properties.RootTaxonId.PropertyValue = null;
+                        // Not taking into account Show empty taxa if filtering by content type is selected
+                        $scope.properties.ShowEmptyTaxa.PropertyValue = false;
                     }
                     else if ($scope.properties.TaxaToDisplay.PropertyValue === 'Selected') {
                         $scope.properties.DynamicContentTypeName.PropertyValue =

--- a/Telerik.Sitefinity.Frontend.Taxonomies/Mvc/Views/FlatTaxonomy/DesignerView.Simple.cshtml
+++ b/Telerik.Sitefinity.Frontend.Taxonomies/Mvc/Views/FlatTaxonomy/DesignerView.Simple.cshtml
@@ -76,7 +76,7 @@
         </label>
     </div>
 
-    <div class="checkbox">
+    <div class="checkbox" ng-hide="properties.TaxaToDisplay.PropertyValue === 'UsedByContentType'">
         <label for="showEmptyTags">
             <input id="showEmptyTags" type="checkbox" ng-model="properties.ShowEmptyTaxa.PropertyValue"
                    ng-true-value="'True'" ng-false-value="'False'" ng-checked="properties.ShowEmptyTaxa.PropertyValue === 'True'" />

--- a/Telerik.Sitefinity.Frontend.Taxonomies/Mvc/Views/HierarchicalTaxonomy/DesignerView.Simple.cshtml
+++ b/Telerik.Sitefinity.Frontend.Taxonomies/Mvc/Views/HierarchicalTaxonomy/DesignerView.Simple.cshtml
@@ -108,7 +108,7 @@
                 </label>
             </div>
 
-            <div class="checkbox">
+            <div class="checkbox" ng-hide="properties.TaxaToDisplay.PropertyValue === 'UsedByContentType'">
                 <label for="showEmpty">
                     <input id="showEmpty" type="checkbox" ng-model="properties.ShowEmptyTaxa.PropertyValue"
                            ng-true-value="'True'" ng-false-value="'False'" ng-checked="properties.ShowEmptyTaxa.PropertyValue === 'True'" />


### PR DESCRIPTION
…t type is selected

- [x] @NadezhdaPetrova 
- [x] @GeorgiMateev

Classification: Show empty tags/categories should be hidden if "Only tags used by content type..." is selected

