### PR TITLE
Feed fixes

### DIFF
--- a/Telerik.Sitefinity.Frontend.Publishing/Mvc/Models/FeedModel.cs
+++ b/Telerik.Sitefinity.Frontend.Publishing/Mvc/Models/FeedModel.cs
@@ -62,15 +62,10 @@ namespace Telerik.Sitefinity.Frontend.Publishing.Mvc.Models
                     }
                     if (this.InsertionOption == FeedInsertionOption.PageOnly || this.InsertionOption == FeedInsertionOption.PageAndAddressBar)
                     {
-                        // TODO: what to do with iconClass?
-                        string openInNewWindowCode = this.OpenInNewWindow ? "target=\"_blank\"" : "";
-                        viewModel.Link = string.Format(
-                            CultureInfo.CurrentCulture, 
-                            @"<a href=""{0}"" title=""{1}"" {2}>{3}</a>", 
-                            url, 
-                            this.Tooltip, 
-                            openInNewWindowCode, 
-                            title);
+                        viewModel.Title = title;
+                        viewModel.Url = url;
+                        viewModel.Tooltip = this.Tooltip;
+                        viewModel.OpenInNewWindow = this.OpenInNewWindow;
                     }
                 }
             }

--- a/Telerik.Sitefinity.Frontend.Publishing/Mvc/Models/FeedViewModel.cs
+++ b/Telerik.Sitefinity.Frontend.Publishing/Mvc/Models/FeedViewModel.cs
@@ -21,10 +21,29 @@ namespace Telerik.Sitefinity.Frontend.Publishing.Mvc.Models
         public string HeadLink { get; set; }
 
         /// <summary>
-        /// Gets or sets the feed link that will be embedded in the page.
+        /// Gets or sets the title.
         /// </summary>
-        /// <value>The link.</value>
-        public string Link { get; set; }
+        /// <value>The title.</value>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL.
+        /// </summary>
+        /// <value>The URL.</value>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1056:UriPropertiesShouldNotBeStrings")]
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tooltip.
+        /// </summary>
+        /// <value>The tooltip.</value>
+        public string Tooltip { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [open in new window].
+        /// </summary>
+        /// <value><c>true</c> if [open in new window]; otherwise, <c>false</c>.</value>
+        public bool OpenInNewWindow { get; set; }
 
         /// <summary>
         /// Gets or sets the CSS class that will be applied on the wrapper div of the widget.

--- a/Telerik.Sitefinity.Frontend.Publishing/Mvc/Scripts/Feed/designerview-simple.js
+++ b/Telerik.Sitefinity.Frontend.Publishing/Mvc/Scripts/Feed/designerview-simple.js
@@ -3,10 +3,36 @@
     angular.module('designer').requires.push('sfSelectors', 'expander');
 
     designerModule.controller('SimpleCtrl', ['$scope', 'propertyService', function ($scope, propertyService) {
+        var emptyGuid = '00000000-0000-0000-0000-000000000000';
+        var doNotLoadTextToDisplay = false;
+
+        $scope.$watch(
+            'feed',
+            function (newFeed, oldFeed) {
+                if (newFeed !== oldFeed) {
+                    if (newFeed && oldFeed && newFeed.Id !== oldFeed.Id) {
+                        // new feed is selected so set TextToDisplay to the new feed title
+                        doNotLoadTextToDisplay = false;
+                    }
+
+                    if (!$scope.properties.TextToDisplay.PropertyValue && !doNotLoadTextToDisplay) {
+                        $scope.properties.TextToDisplay.PropertyValue = newFeed.Title;
+                    }
+                }
+            },
+            true
+        );
+
         propertyService.get()
             .then(function (data) {
                 if (data) {
                     $scope.properties = propertyService.toAssociativeArray(data.Items);
+                    if ($scope.properties.FeedId.PropertyValue &&
+                        $scope.properties.FeedId.PropertyValue !== emptyGuid &&
+                        !$scope.properties.TextToDisplay.PropertyValue) {
+                        // TextToDisplay is set to be empty string so do not set feed title on load
+                        doNotLoadTextToDisplay = true;
+                    }
                 }
             },
             function (data) {

--- a/Telerik.Sitefinity.Frontend.Publishing/Mvc/Views/Feed/DesignerView.Simple.cshtml
+++ b/Telerik.Sitefinity.Frontend.Publishing/Mvc/Views/Feed/DesignerView.Simple.cshtml
@@ -2,7 +2,7 @@
 
 <div class="form-group">   
     <strong>@Html.Resource("WhichFeedToUse")</strong> 
-    <sf-list-selector sf-feed-selector></sf-list-selector>  
+    <sf-list-selector sf-feed-selector sf-selected-item-id="properties.FeedId.PropertyValue" sf-selected-item="feed"></sf-list-selector>  
 </div>
 
 <div class="form-group">
@@ -62,7 +62,7 @@
     <div class="row">
         <div class="col-xs-6">
             <select id="templateName" ng-model="properties.TemplateName.PropertyValue" class="form-control">
-                @foreach (var viewName in Html.GetViewNames(((Telerik.Sitefinity.Mvc.Proxy.MvcProxyBase)Model).Controller, @"Feed\.(?<viewName>[\w\s]*)$"))
+                @foreach (var viewName in Html.GetViewNames(((Telerik.Sitefinity.Mvc.Proxy.MvcProxyBase)Model).Controller, @"^Feed\.(?<viewName>[\w\s]*)$"))
                 {
                     <option value="@viewName"> @viewName</option>
                 }

--- a/Telerik.Sitefinity.Frontend.Publishing/Mvc/Views/Feed/DesignerView.Simple.cshtml
+++ b/Telerik.Sitefinity.Frontend.Publishing/Mvc/Views/Feed/DesignerView.Simple.cshtml
@@ -56,7 +56,7 @@
 	</div>		
 </div>
 
-<div class="form-group">
+<div class="form-group" ng-hide="properties.InsertionOption.PropertyValue == 'AddressBarOnly'">
     <label for="templateName">@Html.Resource("Template")</label>
 
     <div class="row">

--- a/Telerik.Sitefinity.Frontend.Publishing/Mvc/Views/Feed/Feed.FeedLink.cshtml
+++ b/Telerik.Sitefinity.Frontend.Publishing/Mvc/Views/Feed/Feed.FeedLink.cshtml
@@ -3,8 +3,8 @@
 @using Telerik.Sitefinity.Frontend.Publishing.Mvc.Models;
 
 <div class="@Model.CssClass">
-@if ((Model.InsertionOption == FeedInsertionOption.PageOnly || Model.InsertionOption == FeedInsertionOption.PageAndAddressBar) && Model.Link != null)
+@if (Model.InsertionOption == FeedInsertionOption.PageOnly || Model.InsertionOption == FeedInsertionOption.PageAndAddressBar)
 {
-    @Html.Raw(Model.Link)
+    <a href="@Model.Url" title="@Model.Tooltip" @(Model.OpenInNewWindow ? "target=_blank" : "")>@Model.Title</a>
 }
 </div>


### PR DESCRIPTION
Feed widget fixes:

- selected feed is persisted
- fixed TemplateName regular expression in the designer
- TextToDisplay is populated with the feed title
- feed template is fixed in order to be customizable
- template dropdown is hidden when 'Link in the browser address-bar only' option is selected

- [x] @PepiIvanova 
- [x] @GeorgiMateev 