### PR TITLE
Removed default value for the MaxLength limitation in TextField

### DIFF
--- a/Telerik.Sitefinity.Frontend.Forms/Mvc/Scripts/TextField/designerview-simple.js
+++ b/Telerik.Sitefinity.Frontend.Forms/Mvc/Scripts/TextField/designerview-simple.js
@@ -26,6 +26,9 @@
         var onGetPropertiesSuccess = function (data) {
             if (data) {
                 $scope.properties = propertyService.toHierarchyArray(data.Items);
+
+                if ($scope.properties.Model.ValidatorDefinition.MaxLength.PropertyValue === '0')
+                    $scope.properties.Model.ValidatorDefinition.MaxLength.PropertyValue = '';
             }
         };
 


### PR DESCRIPTION
Please review: 
- [x] @dzhenko 
- [x] @Tihomir-Petrov 