### PR TITLE
Image gallery orderopt

### DIFF
--- a/Telerik.Sitefinity.Frontend.Media/Mvc/Scripts/ImageGallery/designerview-simple.js
+++ b/Telerik.Sitefinity.Frontend.Media/Mvc/Scripts/ImageGallery/designerview-simple.js
@@ -2,7 +2,7 @@
     angular.module('designer').requires.push('expander', 'sfSelectors', 'sfThumbnailSizeSelection');
 
     angular.module('designer').controller('SimpleCtrl', ['$scope', 'propertyService', function ($scope, propertyService) {
-        var sortOptions = ['PublicationDate DESC', 'LastModified DESC', 'Title ASC', 'Title DESC'];
+        var sortOptions = ['PublicationDate DESC', 'LastModified DESC', 'Title ASC', 'Title DESC', 'Ordinal ASC'];
 
         var emptyGuid = '00000000-0000-0000-0000-000000000000';
 

--- a/Telerik.Sitefinity.Frontend.Media/Mvc/Views/ImageGallery/DesignerView.Simple.cshtml
+++ b/Telerik.Sitefinity.Frontend.Media/Mvc/Views/ImageGallery/DesignerView.Simple.cshtml
@@ -119,6 +119,7 @@
                         <option value="LastModified DESC"> @Html.Resource("LastModified")</option>
                         <option value="Title ASC"> @Html.Resource("ByTitleAZ")</option>
                         <option value="Title DESC"> @Html.Resource("ByTitleZA")</option>
+                        <option value="Ordinal ASC"> @Html.Resource("AsSetManually")</option>
                         <option value="Custom"> @Html.Resource("AsSetInAdvancedMode")</option>
                     </select>
                 </div>


### PR DESCRIPTION
- [x] @Tihomir-Petrov 
- [x] @ElenaGaneva 

[Image Gallery: Add option to sort images as they are ordered in the image library](https://github.com/Sitefinity/feather/issues/1243)