### PR TITLE
Fix for #196612

### DIFF
--- a/Telerik.Sitefinity.Frontend.Forms/Mvc/Models/Fields/TextField/TextFieldModel.cs
+++ b/Telerik.Sitefinity.Frontend.Forms/Mvc/Models/Fields/TextField/TextFieldModel.cs
@@ -149,9 +149,14 @@ namespace Telerik.Sitefinity.Frontend.Forms.Mvc.Models.Fields.TextField
             
             if (!string.IsNullOrWhiteSpace(this.ValidatorDefinition.ExpectedFormat.ToString()))
             {
-                attributes.Append("pattern=");
-                attributes.Append(this.GetRegExForExpectedFormat(this.ValidatorDefinition.ExpectedFormat));
-                attributes.Append(" ");
+                var pattern = this.GetRegExForExpectedFormat(this.ValidatorDefinition.ExpectedFormat);
+                if(!string.IsNullOrEmpty(pattern))
+                {
+                    attributes.Append("pattern=");
+                    attributes.Append(pattern);
+                    attributes.Append(" ");
+                }
+                
             }
 
             if (this.InputType == TextType.Tel)


### PR DESCRIPTION
Expected format is not taken into account. When there is empty string as
expected format you could not submit the form.