### PR TITLE
Dynamic content view bug fix

### DIFF
--- a/Telerik.Sitefinity.Frontend.DynamicContent/Mvc/Models/DynamicContentModel.cs
+++ b/Telerik.Sitefinity.Frontend.DynamicContent/Mvc/Models/DynamicContentModel.cs
@@ -129,6 +129,15 @@ namespace Telerik.Sitefinity.Frontend.DynamicContent.Mvc.Models
             return new DynamicContentListViewModel();
         }
 
+        /// <inheritdoc />
+        protected override IManager GetManager()
+        {
+            if (this.ContentType == null)
+                throw new InvalidOperationException("Cannot resolve manager because ContentType is not set.");
+
+            return this.GetManagerInstance();
+        }
+
         /// <summary>
         /// Gets the manager instance.
         /// </summary>


### PR DESCRIPTION
#200073 Feather: DynamicContentView creates Content locations with wrong provider

#200407 Feather: Filter by related data item doesn't work when DynamicContentWidget uses default provider for site, which is not OpenAccessProvider

- [x] @gsashev 