### PR TITLE
Fix list item name for DEC tracking #1964

### DIFF
--- a/Telerik.Sitefinity.Frontend.Lists/Mvc/Scripts/Lists/lists.js
+++ b/Telerik.Sitefinity.Frontend.Lists/Mvc/Scripts/Lists/lists.js
@@ -41,7 +41,7 @@
                 link.removeClass('expanded');
             } else {
                 link.addClass('expanded');
-                var itemTitle = link.html();
+                var itemTitle = link.text().trim();
                 sendSentence(itemTitle);
             }
 


### PR DESCRIPTION
Name was incorrectly loaded from the DOM element with trailing spaces and parasite html code.

Reviewers:
- [x] @ADimanova 
- [x] @vassildinev 