### PR TITLE
Modified existing test to wait for ASP.NET cache invalidation, extended it to cover an extra case and added a test that verifies view compilation when overwriting the view file.

### DIFF
--- a/Tests/FeatherWidgets.TestIntegration/Common/WidgetCompilationPerformanceTests.cs
+++ b/Tests/FeatherWidgets.TestIntegration/Common/WidgetCompilationPerformanceTests.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.IO;
 using FeatherWidgets.TestUtilities.CommonOperations;
 using MbUnit.Framework;
 using Telerik.Sitefinity.Frontend.ContentBlock.Mvc.Controllers;
 using Telerik.Sitefinity.Frontend.TestUtilities;
 using Telerik.Sitefinity.Frontend.TestUtilities.CommonOperations;
 using Telerik.Sitefinity.Modules.Pages;
+using Telerik.Sitefinity.Pages.Model;
 using Telerik.Sitefinity.TestUtilities.CommonOperations;
 using Telerik.Sitefinity.TestUtilities.Modules.Diagnostics;
 using Telerik.Sitefinity.Web;
@@ -19,30 +21,24 @@ namespace FeatherWidgets.TestIntegration.Common
     [Description("This class contains tests for the performance method region and tracking razor view compilations.")]
     public class WidgetCompilationPerformanceTests : ProfilingTestBase
     {
+        #region Tests
+
         /// <summary>
-        /// Tears down.
+        /// Verifies that when widget template is edited and page is requested the execution and the compilation of the MVC widgets is logged correctly.
         /// </summary>
-        [TearDown]
-        public override void TestTearDown()
-        {
-            base.TestTearDown();
-
-            ServerOperations.Pages().DeleteAllPages();
-        }
-
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "Telerik.Sitefinity.TestUtilities.CommonOperations.WidgetOperations.AddContentBlockToPage(System.Guid,System.String,System.String,System.String)"), Test]
         [Author(FeatherTeams.FeatherTeam)]
         [Description("Verifies that when widget template is edited and page is requested the execution and the compilation of the MVC widgets is logged correctly.")]
-        public void EditView_RequestPage_CompilationLoggedCorrectly()
+        public void ModifiedView_RequestPage_ShouldLogCompilation()
         {
-            string packageName = "Bootstrap";
             string viewFileName = "Default.cshtml";
             string widgetName = "ContentBlock";
 
             var widgetText = @"@Html.Raw(Model.Content)";
             var widgetTextEdited = @"edited @Html.Raw(Model.Content)";
-            string filePath = FeatherServerOperations.ResourcePackages().GetResourcePackageMvcViewDestinationFilePath(packageName, widgetName, viewFileName);
+            string filePath = FeatherServerOperations.ResourcePackages().GetResourcePackageMvcViewDestinationFilePath(ResourcePackages.Bootstrap, widgetName, viewFileName);
 
+            PageNode pageNode = null;
             try
             {
                 this.EnableProfiler("HttpRequestsProfiler");
@@ -53,35 +49,148 @@ namespace FeatherWidgets.TestIntegration.Common
                 var pageId = ServerOperations.Pages().CreatePage("TestPage1", templateId);
                 var pageNodeId = ServerOperations.Pages().GetPageNodeId(pageId);
                 var pageManager = Telerik.Sitefinity.Modules.Pages.PageManager.GetManager();
-                var pageNode = pageManager.GetPageNode(pageNodeId);
+                pageNode = pageManager.GetPageNode(pageNodeId);
                 var fullPageUrl = RouteHelper.GetAbsoluteUrl(pageNode.GetUrl());
 
-                for (var i = 0; i < 3; i++)
+                int widgetCount = 3;
+                for (var i = 0; i < widgetCount; i++)
                     ServerOperationsFeather.Pages().AddContentBlockWidgetToPage(pageNodeId, "ContentBlock", "Contentplaceholder1");
 
+                this.ExecuteAuthenticatedRequest(fullPageUrl);
+                this.FlushData();
+                this.ClearData();
+
+                var viewPath = "~/Frontend-Assembly/Telerik.Sitefinity.Frontend.ContentBlock/Mvc/Views/ContentBlock/Default.cshtml";
+                var fullViewPath = string.Concat(viewPath, "#Bootstrap.cshtml");
+
                 FeatherServerOperations.ResourcePackages().EditLayoutFile(filePath, widgetText, widgetTextEdited);
-                System.Threading.Thread.Sleep(1000);
+                this.WaitForAspNetCacheToBeInvalidated(fullViewPath);
+
+                // Request page
+                this.ExecuteAuthenticatedRequest(fullPageUrl);
+                this.FlushData();
+
+                this.AssertWidgetExecutionCount(widgetCount);
+                this.AssertViewCompilationCount(1);
+
+                // Assert data
+                var rootOperationId = this.GetRequestLogRootOperationId(fullPageUrl);
+
+                var widgetCompilationText = "Compile view \"Default.cshtml#Bootstrap.cshtml\" of controller \"" + typeof(ContentBlockController).FullName + "\"";
+                this.AssertViewCompilationParams(rootOperationId, viewPath, widgetCompilationText);
+
+                this.ClearData();
+
+                // Request page again
+                this.ExecuteAuthenticatedRequest(fullPageUrl);
+                this.FlushData();
+
+                // Assert new data
+                this.AssertWidgetExecutionCount(widgetCount);
+                this.AssertViewCompilationCount(0);
+            }
+            finally
+            {
+                FeatherServerOperations.ResourcePackages().EditLayoutFile(filePath, widgetTextEdited, widgetText);
+                this.DeletePages(pageNode);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when widget template file is overwritten and page is requested the execution and the compilation of the MVC widget is logged.
+        /// </summary>
+        [Test]
+        [Author(FeatherTeams.FeatherTeam)]
+        [Description("Verifies that when widget template file is overwritten and page is requested the execution and the compilation of the MVC widget is logged.")]
+        public void OverwrittenView_RequestPage_ShouldLogRazorViewCompilation()
+        {
+            string viewFileName = "Default.cshtml";
+            string widgetName = "ContentBlock";
+
+            string filePath = FeatherServerOperations.ResourcePackages().GetResourcePackageMvcViewDestinationFilePath(ResourcePackages.Bootstrap, widgetName, viewFileName);
+
+            PageNode pageNode = null;
+            try
+            {
+                this.EnableProfiler("HttpRequestsProfiler");
+                this.EnableProfiler("WidgetExecutionsProfiler");
+                this.EnableProfiler("RazorViewCompilationsProfiler");
+
+                Guid templateId = Telerik.Sitefinity.TestUtilities.CommonOperations.ServerOperations.Templates().GetTemplateIdByTitle(PageTemplateName);
+                var pageId = ServerOperations.Pages().CreatePage("TestPage1", templateId);
+                var pageNodeId = ServerOperations.Pages().GetPageNodeId(pageId);
+                var pageManager = Telerik.Sitefinity.Modules.Pages.PageManager.GetManager();
+                pageNode = pageManager.GetPageNode(pageNodeId);
+                var fullPageUrl = RouteHelper.GetAbsoluteUrl(pageNode.GetUrl());
+
+                int widgetCount = 3;
+                for (var i = 0; i < widgetCount; i++)
+                    ServerOperationsFeather.Pages().AddContentBlockWidgetToPage(pageNodeId, "ContentBlock", "Contentplaceholder1");
+
+                this.ExecuteAuthenticatedRequest(fullPageUrl);
+                this.FlushData();
+                this.ClearData();
+
+                var viewPath = "~/Frontend-Assembly/Telerik.Sitefinity.Frontend.ContentBlock/Mvc/Views/ContentBlock/Default.cshtml";
+                var fullViewPath = string.Concat(viewPath, "#Bootstrap.cshtml");
+
+                this.OvewriteFile(filePath);
+                this.WaitForAspNetCacheToBeInvalidated(fullViewPath);
 
                 // request page
                 this.ExecuteAuthenticatedRequest(fullPageUrl);
                 this.FlushData();
 
-                this.AssertWidgetExecutionCount(3);
+                this.AssertWidgetExecutionCount(widgetCount);
                 this.AssertViewCompilationCount(1);
 
                 // Assert data
                 var rootOperationId = this.GetRequestLogRootOperationId(fullPageUrl);
-                
+
                 var widgetCompilationText = "Compile view \"Default.cshtml#Bootstrap.cshtml\" of controller \"" + typeof(ContentBlockController).FullName + "\"";
-                var viewPath = "~/Frontend-Assembly/Telerik.Sitefinity.Frontend.ContentBlock/Mvc/Views/ContentBlock/Default.cshtml";
                 this.AssertViewCompilationParams(rootOperationId, viewPath, widgetCompilationText);
+
+                this.ClearData();
+
+                // Request page again
+                this.ExecuteAuthenticatedRequest(fullPageUrl);
+                this.FlushData();
+
+                // Assert new data
+                this.AssertWidgetExecutionCount(widgetCount);
+                this.AssertViewCompilationCount(0);
             }
             finally
             {
-                FeatherServerOperations.ResourcePackages().EditLayoutFile(filePath, widgetTextEdited, widgetText);
+                this.DeletePages(pageNode);
             }
         }
 
+        #endregion
+
+        #region Private Methods
+
+        private void OvewriteFile(string filePath)
+        {
+            string contents = File.ReadAllText(filePath);
+            contents += " ";
+
+            File.Delete(filePath);
+            File.WriteAllText(filePath, contents);
+        }
+
+        #endregion
+
+        #region Fields and Constants
+
+        private struct ResourcePackages
+        {
+            public const string Bootstrap = "Bootstrap";
+        }
+
+        private const string WidgetViewPathFormat = "";
         private const string PageTemplateName = "Bootstrap.default";
+
+        #endregion
     }
 }


### PR DESCRIPTION
For review:
- [x] @ElenaGaneva 
- [x] @Boyko-Karadzhov 