### PR TITLE
Fix for bug #205754: Feather Forms: Cannot submit if one form is using Ajax Submit and other form is not

### DIFF
--- a/Telerik.Sitefinity.Frontend.Forms/Mvc/Scripts/Form/form-ajax.js
+++ b/Telerik.Sitefinity.Frontend.Forms/Mvc/Scripts/Form/form-ajax.js
@@ -3,7 +3,7 @@
         return;
 
     $(function () {
-        var formContainers = $('[data-sf-role="form-container"]');
+        var formContainers = $('[data-sf-role="form-container"]:has([data-sf-role="ajax-submit-url"])');
         formContainers.each(function (i, element) {
             var formContainer = $(element);
             var loadingImg = formContainer.find('[data-sf-role="loading-img"]');


### PR DESCRIPTION
For review:
- [x] @Boyko-Karadzhov 