### PR TITLE
Update TextFieldModel to correctly append regular expression patterns

### DIFF
--- a/Telerik.Sitefinity.Frontend.Forms/Mvc/Models/Fields/TextField/TextFieldModel.cs
+++ b/Telerik.Sitefinity.Frontend.Forms/Mvc/Models/Fields/TextField/TextFieldModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
+using System.Web;
 using System.Web.Mvc;
 using System.Web.Script.Serialization;
 using System.Web.UI;
@@ -146,44 +147,37 @@ namespace Telerik.Sitefinity.Frontend.Forms.Mvc.Models.Fields.TextField
                 minMaxLength = ".{" + this.ValidatorDefinition.MinLength + "," + this.ValidatorDefinition.MaxLength + "}";
             else if (this.ValidatorDefinition.MinLength > 0)
                 minMaxLength = ".{" + this.ValidatorDefinition.MinLength + ",}";
-            
-            if (!string.IsNullOrWhiteSpace(this.ValidatorDefinition.ExpectedFormat.ToString()))
+
+            if (!string.IsNullOrEmpty(this.validatorDefinition.RegularExpression))
+            {
+                attributes.Append($"pattern=\"{HttpUtility.HtmlAttributeEncode(this.validatorDefinition.RegularExpression)}\" ");
+            }
+            else if (!string.IsNullOrWhiteSpace(this.ValidatorDefinition.ExpectedFormat.ToString()))
             {
                 var pattern = this.GetRegExForExpectedFormat(this.ValidatorDefinition.ExpectedFormat);
                 if(!string.IsNullOrEmpty(pattern))
                 {
-                    attributes.Append("pattern=");
-                    attributes.Append(pattern);
-                    attributes.Append(" ");
+                    attributes.Append($"pattern=\"{HttpUtility.HtmlAttributeEncode(pattern)}\" ");
                 }
                 
             }
-
-            if (!string.IsNullOrEmpty(this.validatorDefinition.RegularExpression))
+            else if (this.InputType == TextType.Tel)
             {
-                attributes.Append("pattern=");
-                attributes.Append(this.validatorDefinition.RegularExpression);
-                attributes.Append(" ");
-            }
+                StringBuilder regExPattern = new StringBuilder();
 
-            if (this.InputType == TextType.Tel)
-            {
-                attributes.Append("pattern=");
                 if (!string.IsNullOrEmpty(minMaxLength))
                 {
-                    attributes.Append("(?=^");
-                    attributes.Append(minMaxLength);
-                    attributes.Append("$)");
+                    regExPattern.Append("(?=^");
+                    regExPattern.Append(minMaxLength);
+                    regExPattern.Append("$)");
                 }
+                regExPattern.Append(Validator.TelRegexPattern);
 
-                attributes.Append(Validator.TelRegexPattern);
-                attributes.Append(" ");
+                attributes.Append($"pattern=\"{HttpUtility.HtmlAttributeEncode(regExPattern.ToString())}\" ");
             }
             else if (!string.IsNullOrEmpty(minMaxLength))
             {
-                attributes.Append("pattern=");
-                attributes.Append(minMaxLength);
-                attributes.Append(" ");
+                attributes.Append($"pattern=\"{HttpUtility.HtmlAttributeEncode(minMaxLength)}\" ");
             }
 
             return attributes.ToString();


### PR DESCRIPTION
- Fix issue #2036
- Only write 1 pattern attribute (before only the first pattern attribute applied anyway, not it's explicitly only specifying 1 pattern).
- The `validatorDefinition.RegularExpression` now takes precedence over `ValidatorDefinition.ExpectedFormat` (which makes more sense to me)