### PR TITLE
Make InitializeViewModel virtual

### DIFF
--- a/Telerik.Sitefinity.Frontend.Identity/Mvc/Models/Registration/RegistrationModel.cs
+++ b/Telerik.Sitefinity.Frontend.Identity/Mvc/Models/Registration/RegistrationModel.cs
@@ -219,7 +219,7 @@ namespace Telerik.Sitefinity.Frontend.Identity.Mvc.Models.Registration
         #region Public methods
 
         /// <inheritDoc/>
-        public void InitializeViewModel(RegistrationViewModel viewModel)
+        public virtual void InitializeViewModel(RegistrationViewModel viewModel)
         {
             if(viewModel != null)
             {


### PR DESCRIPTION
Make InitializeViewModel virtual so developers can create their own custom view model and extend this class overriding this method to use it after rebinding